### PR TITLE
specify launch type as EC2

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -9,6 +9,7 @@ gitRepoCredentialsId: GITHUB_ACCESS_TOKEN
 healthCheckTimeoutSeconds: 45
 healthCheckIntervalSeconds: 60
 listenerPort: 443
+launchType: EC2
 envVars:
   - name: GEOSERVER_DATA_DIR
     value: /data


### PR DESCRIPTION
Add new parameter launchType to pipeline.yml.  The default launchType for the cluster is fargate, but we want geoserver to run with EC2.