### PR TITLE
IOW-717 Change geoserver cpu to 512

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -9,7 +9,6 @@ gitRepoCredentialsId: GITHUB_ACCESS_TOKEN
 healthCheckTimeoutSeconds: 45
 healthCheckIntervalSeconds: 60
 listenerPort: 443
-launchType: EC2
 envVars:
   - name: GEOSERVER_DATA_DIR
     value: /data

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,6 +1,7 @@
 projectName: wqp-external
 dockerImageName: kartoza/geoserver
 memory: 3072
+cpu: 512
 applicationName: wqp-geoserver
 containerPort: 8080
 healthCheck: /geoserver/web/


### PR DESCRIPTION
Geoserver runs with a memory of 3072.  As per fargate requirements, the minimum cpu is 512.  Since we are using 256 as the default for everything else, override that default in pipeline.yml